### PR TITLE
NEW keep version number on restore (PR #56)

### DIFF
--- a/admin/propalehistory_setup.php
+++ b/admin/propalehistory_setup.php
@@ -41,6 +41,9 @@ if (! $user->admin) {
 // Parameters
 $action = GETPOST('action', 'alpha');
 
+// keep version number on restoring
+$formSetup->newItem('PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM')->setAsYesNo();
+
 /*
  * Actions
  */

--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -236,9 +236,20 @@ class ActionsPropalehistory
 		} elseif($actionATM == 'restaurer') {
             if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
                 $versionNumSelected = GETPOST('versionNum', 'int');
+
+                // save current proposal version before restoring
+                $currentProposal = new Propal($db);
+                $currentProposal->fetch($object->id);
+                $result = TPropaleHist::archiverPropale($ATMdb, $currentProposal);
+                if ($result < 0) {
+                    setEventMessages($currentProposal->error, $object->errors, 'errors');
+                    header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+                    exit();
+                }
             } else {
                 $versionNumSelected = 0;
             }
+
 			TPropaleHist::restaurerPropale($ATMdb, $object, $versionNumSelected);
 		} elseif($actionATM == 'supprimer') {
 

--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -11,28 +11,30 @@ class ActionsPropalehistory
     function formObjectOptions($parameters, &$object, &$action, $hookmanager)
     {
       	global $conf,$langs,$db;
+        $newToken = function_exists('newToken') ? newToken() : $_SESSION['newtoken'];
 		define('INC_FROM_DOLIBARR', true);
 		dol_include_once("/propalehistory/config.php");
 		dol_include_once("/comm/propal/class/propal.class.php");
 
 		if (in_array('propalcard',explode(':',$parameters['context'])))
         {
-
+            /**
+             * @var Propal $object
+             */
 	        if($action != 'create' && $action != 'statut' && $action != 'presend') {
 	    		dol_include_once("/propalehistory/class/propaleHist.class.php");
-				$ATMdb = new TPDOdb;
-
 
 		    	$actionATM = GETPOST('actionATM');
 		    	$url=DOL_URL_ROOT.'/comm/propal.php';
                 if ((float) DOL_VERSION >= 4.0) {
                     $url=DOL_URL_ROOT.'/comm/propal/card.php';
                 }
-				if($actionATM == 'viewVersion') {
+				if ($actionATM == 'viewVersion') {
+                    $versionNumSelected = GETPOST('propalehistory_version_num_selected', 'int');
 					?>
 						<script type="text/javascript">
 							$(document).ready(function() {
-								$('div.tabsAction').html('<?php echo '<div class="inline-block divButAction"><a id="returnCurrent" href="'.$_SERVER['PHP_SELF'].'?id='.$_REQUEST['id'].'">'.$langs->trans('ReturnInitialVersion').'</a> <a id="butRestaurer" class="butAction" href="'.$url.'?id='.$_REQUEST['id'].'&actionATM=restaurer&idVersion='.$_REQUEST['idVersion'].'">'.$langs->trans('Restaurer').'</a><a id="butSupprimer" class="butActionDelete" href="'.$url.'?id='.$_REQUEST['id'].'&actionATM=supprimer&idVersion='.$_REQUEST['idVersion'].'">'.$langs->trans('Delete').'</a></div>'?>');
+                                $('div.tabsAction').html('<?php echo '<div class="inline-block divButAction"><a id="returnCurrent" href="'.$_SERVER['PHP_SELF'].'?id='.$_REQUEST['id'].'&token='.$newToken.'">'.$langs->trans('ReturnInitialVersion').'</a> <a id="butRestaurer" class="butAction" href="'.$url.'?id='.$_REQUEST['id'].'&actionATM=restaurer&idVersion='.$_REQUEST['idVersion'].'&token='.$newToken.'&versionNum='.$versionNumSelected.'">'.$langs->trans('Restaurer').'</a><a id="butSupprimer" class="butActionDelete" href="'.$url.'?id='.$_REQUEST['id'].'&actionATM=supprimer&idVersion='.$_REQUEST['idVersion'].'">'.$langs->trans('Delete').'</a></div>'?>');
 								$('#butRestaurer').insertAfter('#voir');
 								$('#butSupprimer').insertBefore('#voir');
 								$('#builddoc_form').hide();
@@ -40,11 +42,7 @@ class ActionsPropalehistory
 						</script>
 
 					<?php
-
-					TPropaleHist::listeVersions($db, $object);
-				} elseif($actionATM == 'createVersion') {
-					TPropaleHist::listeVersions($db, $object);
-				} elseif($actionATM == '' && $object->statut == 1) {
+				} elseif ($actionATM == '' && $object->statut == 1) {
                     // TODO Pourquoi c'est ici et pas dans un addMoreActionsButtons ?
 					print '<div id="butNewVersion" class="inline-block divButAction"><a class="butAction" href="'.$_SERVER['PHP_SELF'].'?id='.$_REQUEST['id'].'&actionATM=createVersion">'.$langs->trans('PropaleHistoryArchiver').'</a></div>';
 					?>
@@ -54,26 +52,18 @@ class ActionsPropalehistory
 							})
 						</script>
 					<?php
-					$num = TPropaleHist::listeVersions($db, $object);
 				}
-				else {
+                $versionNum = TPropaleHist::listeVersions($db, $object);
 
-					$num = TPropaleHist::listeVersions($db, $object);
-
-
-				}
-				if(!empty($num) && ! $conf->global->PROPALEHISTORY_HIDE_VERSION_ON_TABS) {
+				if ($versionNum > 1 && !$conf->global->PROPALEHISTORY_HIDE_VERSION_ON_TABS) {
 					?>
 						<script type="text/javascript">
-							$("a#comm").first().append(" / v. <?php echo $num +1 ?>");
+							$("a#comm").first().append(" / v. <?php echo $versionNum; ?>");
 						console.log($("a#comm").first());
 						</script>
 					<?php
-
 				}
-
 			}
-
 		}
 
 		return 0;
@@ -95,6 +85,7 @@ class ActionsPropalehistory
 
 				// Restore ref
 				$obj->ref = $original_ref;
+                $obj->context['propale_history']['original_ref'] = null;
 			}
 		}
 
@@ -118,12 +109,11 @@ class ActionsPropalehistory
 				dol_include_once("/comm/propal/class/propal.class.php");
 				dol_include_once('/propalehistory/class/propaleHist.class.php');
 
-				$TVersion = TPropaleHist::getVersions($db, $obj->id);
-				$num = count($TVersion);
+                $versionNum = TPropaleHist::getVersionNumFromProposalOrVersionList($db, $obj);
 
-				if ($num > 0) {
+				if ($versionNum > 1) {
 					$obj->context['propale_history'] = array('original_ref' => $obj->ref);
-					$obj->ref .= '/' . ($num + 1);
+					$obj->ref .= '/' . ($versionNum);
 				}
 			}
 		}
@@ -195,7 +185,12 @@ class ActionsPropalehistory
 				// New version if wanted
 				$archive_proposal = GETPOST('archive_proposal', 'alpha');
 				if ($archive_proposal == 'on') {
-					TPropaleHist::archiverPropale($ATMdb, $object);
+					$result = TPropaleHist::archiverPropale($ATMdb, $object);
+                    if ($result < 0) {
+                        setEventMessages($object->error, $object->errors, 'errors');
+                        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+                        exit();
+                    }
 				}
 				$action = 'modif'; // On provoque le repassage-en brouillon
 
@@ -230,13 +225,21 @@ class ActionsPropalehistory
 			$object->id = $_REQUEST['id'];
 			$object->db = $db;
 		} elseif($actionATM == 'createVersion') {
-
-			TPropaleHist::archiverPropale($ATMdb, $object);
-
+			$result = TPropaleHist::archiverPropale($ATMdb, $object);
+            if ($result < 0) {
+                setEventMessages($object->error, $object->errors, 'errors');
+            } else {
+                setEventMessage($langs->transnoentities('HistoryVersionSuccessfullArchived'), 'mesgs');
+            }
+            header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+            exit();
 		} elseif($actionATM == 'restaurer') {
-
-			TPropaleHist::restaurerPropale($ATMdb, $object);
-
+            if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                $versionNumSelected = GETPOST('versionNum', 'int');
+            } else {
+                $versionNumSelected = 0;
+            }
+			TPropaleHist::restaurerPropale($ATMdb, $object, $versionNumSelected);
 		} elseif($actionATM == 'supprimer') {
 
 			$version = new TPropaleHist;

--- a/class/propaleHist.class.php
+++ b/class/propaleHist.class.php
@@ -1,6 +1,11 @@
 <?php
 	class TPropaleHist extends TObjetStd {
 
+        /**
+         * @var array options
+         */
+        public $array_options = array();
+
 		function __construct() {
 			parent::set_table(MAIN_DB_PREFIX.'propale_history');
 			parent::add_champs('serialized_parent_propale',array('type'=>'text'));
@@ -47,6 +52,13 @@
 			return $propal;
 		}
 
+        /**
+         * Archive proposal
+         *
+         * @param   TPDOdb  $PDOdb      PDO connection
+         * @param   Propal  $object     Proposal object
+         * @return  int     <0 if KO, >0 if OK
+         */
 		static function archiverPropale(&$PDOdb, &$object)
 		{
 			global $conf, $db, $langs;
@@ -54,6 +66,26 @@
 			if (!empty($conf->global->PROPALEHISTORY_ARCHIVE_PDF_TOO)) {
 				TPropaleHist::archivePDF($object);
 			}
+
+            // set proposal version number before saving
+            $update_extras = false;
+            if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                $object->array_options['options_propalehistory_version_num'] = self::getVersionNumNext($db, $object->id); // get next version number
+                $update_extras = true;
+            } else {
+                if (!empty($object->array_options['options_propalehistory_version_num'])) {
+                    $object->array_options['options_propalehistory_version_num'] = null; // reset version number
+                    $update_extras = true;
+                }
+            }
+            if ($update_extras === true) {
+                $res = $object->insertExtraFields();
+                if ($res < 0) {
+                    return -1;
+                }
+            }
+
+            $error = 0;
 
 			$newVersionPropale = new TPropaleHist;
 			$newVersionPropale->setObject($object);
@@ -78,14 +110,16 @@
                 dol_syslog(__METHOD__, LOG_DEBUG);
                 $resql = $db->query($sql);
                 if (!$resql) {
-                    $error_msg = $db->lasterror();
+                    $error++;
+                    $object->error = $db->lasterror();
+                    $object->errors[] = $object->error;
                     $db->rollback();
-                    dol_syslog(__METHOD__, 'Error : ' . $error_msg, LOG_ERR);
+                    dol_syslog(__METHOD__ . ' Error : ' . $object->error, LOG_ERR);
                 } else {
                     $db->commit();
                 }
 
-                if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
+                if (!$error && empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {
                     // reload the object with new lines
                     $ret = $object->fetch($object->id);
                     $ret = $object->fetch_thirdparty($object->socid);
@@ -106,11 +140,21 @@
                     $object->generateDocument($object->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
                 }
             }
-			?>
-				<script language="javascript">
-					document.location.href="<?php echo $_SERVER['PHP_SELF'] ?>?id=<?php echo $_REQUEST['id']?>&mesg=<?php echo $langs->transnoentities('HistoryVersionSuccessfullArchived') ?>";
-				</script>
-			<?php
+
+            // update to next version to work on (only if we work on last version)
+            if (!$error && !empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                $object->array_options['options_propalehistory_version_num']++;
+                $res = $object->insertExtraFields();
+                if ($res < 0) {
+                    $error++;
+                }
+            }
+
+            if (!$error) {
+                return 1;
+            } else {
+                return -1;
+            }
 
 
 			/*if($_REQUEST['actionATM'] == 'createVersion') {
@@ -129,16 +173,8 @@
 		{
 			global $db;
 
-			$sql = "";
-			$sql.= " SELECT count(*) as nb";
-			$sql.= " FROM ".MAIN_DB_PREFIX."propale_history";
-			$sql.= " WHERE fk_propale = ".$object->id;
-			$resql = $db->query($sql);
+            $versionNum = self::getVersionNumFromProposalOrVersionList($db, $object);
 
-			$nb=1;
-			if ($resql && ($row = $db->fetch_object($resql))) $nb = $row->nb + 1;
-
-			$ok = 1;
 			if ($object->entity > 1) {
 				$filename = DOL_DATA_ROOT . '/' . $object->entity . '/propale/' . $object->ref . '/' .$object->ref;
 				$path = DOL_DATA_ROOT . '/' . $object->entity . '/propale/' . $object->ref . '/' .$object->ref . '.pdf';
@@ -148,11 +184,11 @@
 				$path = DOL_DATA_ROOT . '/propale/' . $object->ref . '/' .$object->ref . '.pdf';
 			}
 
-			if (!is_file($path)) $ok = TPropaleHist::generatePDF($object);
+            $ok = TPropaleHist::generatePDF($object);
 
 			if ($ok > 0)
 			{
-				exec('cp "'.$path.'" "'.$filename.'-'.$nb.'.pdf"');
+				exec('cp "'.$path.'" "'.$filename.'-'.$versionNum.'.pdf"');
 			}
 		}
 
@@ -163,7 +199,15 @@
 			return $object->generateDocument($conf->global->PROPALE_ADDON_PDF, $langs, 0, 0, 0);
 		}
 
-		static function restaurerPropale(&$PDOdb, &$object) {
+        /**
+         * Restore a proposal
+         *
+         * @param   PDO     $PDOdb                  Database connection
+         * @param   Propal  $object                 Proposal object
+         * @param   int     $versionNum             [=0] To restore on new version or version number to restore on
+         * @return  void
+         */
+		static function restaurerPropale(&$PDOdb, &$object, $versionNum = 0) {
 
 			global $db, $user,$langs;
 
@@ -227,6 +271,8 @@
                 $newProposalLineIdList[$lineNum] = $object->line->id;
 			}
 
+            $object->array_options['options_propalehistory_version_num'] = (empty($versionNum) ? null : $versionNum);
+
 			if (method_exists($object, 'set_draft')) $object->set_draft($user); // Pour pouvoir modifier les dates, le statut doit être à 0
 			else $object->setDraft($user);
 
@@ -256,10 +302,91 @@
              */
 		}
 
+        /**
+         * Get version number from proposal
+         *
+         * @param   DoliDB      $db             Database connection
+         * @param   Propal      $proposal       Proposal object
+         * @param   array       $versionList    [=array()] Version list
+         * @return  int
+         */
+        public static function getVersionNumFromProposalOrVersionList(&$db, $proposal, $versionList = array())
+        {
+            global $conf;
+
+            $fromVersionList = false;
+
+            if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                if (!empty($proposal->array_options['options_propalehistory_version_num'])) {
+                    $versionNum = $proposal->array_options['options_propalehistory_version_num'];
+                } else {
+                    $fromVersionList = true;
+                }
+            } else {
+                $fromVersionList = true;
+            }
+
+            if ($fromVersionList === true) {
+                if (empty($versionList)) {
+                    $versionList = self::getVersions($db, $proposal->id);
+                }
+                $versionNumLast = self::getVersionNumLastFromVersionList($versionList);
+                $versionNum = $versionNumLast + 1;
+            }
+
+            return $versionNum;
+        }
+
+        /**
+         * Get next version number
+         *
+         * @param   DoliDB  $db             Database connection
+         * @param   int     $fk_object      Proposal id
+         * @return  int     Next version number
+         */
+        protected static function getVersionNumNext(&$db, $fk_object) {
+            $TVersion = self::getVersions($db, $fk_object);
+            $versionNumLast = self::getVersionNumLastFromVersionList($TVersion);
+            return $versionNumLast + 1;
+        }
+
+        /**
+         * Get last version number
+         *
+         * @param   array       $versionList    [=array()] Version list
+         * @return  int         Last version number
+         */
+        protected static function getVersionNumLastFromVersionList($versionList = array())
+        {
+            global $conf;
+
+            $versionNumLast = 0;
+
+            if (!empty($versionList)) {
+                $versionNumLast = count($versionList);
+
+                if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                    $versionPropale = new TPropaleHist;
+
+                    foreach ($versionList as $row) {
+                        $versionPropale->serialized_parent_propale = $row->serialized_parent_propale;
+                        $propale = $versionPropale->getObject();
+                        if (!empty($propale->array_options['options_propalehistory_version_num'])) {
+                            if ($propale->array_options['options_propalehistory_version_num'] > $versionNumLast) {
+                                $versionNumLast = $propale->array_options['options_propalehistory_version_num'];
+                            }
+                        }
+                    }
+                }
+            }
+
+            return $versionNumLast;
+        }
+
 		static function getVersions(&$db, $fk_object) {
 
 			$sql = "";
-			$sql.= " SELECT rowid, date_version, date_cre, total";
+			$sql.= " SELECT rowid, date_version, date_cre, total, serialized_parent_propale";
 			$sql.= " FROM ".MAIN_DB_PREFIX."propale_history";
 			$sql.= " WHERE fk_propale = ".$fk_object;
 			$sql.= " ORDER BY rowid ASC";
@@ -279,12 +406,20 @@
 			return $TVersion;
 		}
 
+        /**
+         * Show proposals versions and get current version number
+         *
+         * @param   DoliDb      $db         Database connection
+         * @param   Propal      $object     Proposal object
+         * @return  int
+         */
 		static function listeVersions(&$db, $object) {
 			global $langs,$conf,$hookmanager;
 			$TVersion = self::getVersions($db, $object->id);
 
 
 			$num = count($TVersion);
+            $versionNumCurrent = self::getVersionNumFromProposalOrVersionList($db, $object, $TVersion);
 
 			$url=DOL_URL_ROOT.'/comm/propal.php';
 			if ((float) DOL_VERSION >= 4.0) {
@@ -302,20 +437,32 @@
 					print '<input type="hidden" name="token" value="'.newToken().'" />';
 				}
 
-				print '<select name="idVersion">';
+				print '<select id="propalehistory_id" name="idVersion">';
 				$i = 1;
+                $versionNumSelected = $i;
 
-				foreach($TVersion as &$row){
+				foreach ($TVersion as &$row) {
+                    $versionNumRow = $i;
+                    if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
+                        $versionPropale = new TPropaleHist;
+                        $versionPropale->serialized_parent_propale = $row->serialized_parent_propale;
+                        $propale = $versionPropale->getObject();
+                        if (!empty($propale->array_options['options_propalehistory_version_num'])) {
+                            $versionNumRow = $propale->array_options['options_propalehistory_version_num'];
+                        }
+                    }
 
 					if(isset($_REQUEST['idVersion']) && $_REQUEST['idVersion'] == $row->rowid){
 						$selected = 'selected="selected"';
+                        $versionNumCurrent = $versionNumRow;
+                        $versionNumSelected = $versionNumRow;
 					} else {
 						$selected = "";
 					}
 
-					$options = '<option id="' . $row->rowid . '" value="' . $row->rowid . '" ' . $selected . '>'.$langs->trans('VersionNumberShort').' ' . $i . ' - ' . price($row->total) . ' ' . $langs->getCurrencySymbol($conf->currency, 0) . ' - ' . dol_print_date($db->jdate($row->date_cre), "dayhour") . '</option>';
+					$options = '<option id="' . $row->rowid . '" value="' . $row->rowid . '" ' . $selected . ' data-version-num="' . $versionNumRow . '">'.$langs->trans('VersionNumberShort').' ' . $versionNumRow . ' - ' . price($row->total) . ' ' . $langs->getCurrencySymbol($conf->currency, 0) . ' - ' . dol_print_date($db->jdate($row->date_cre), "dayhour") . '</option>';
 					$hookmanager->initHooks(array('propalehistory'));
-					$parameters = array('row' => $row, 'selected' => $selected, 'versionNumber' => $i);
+					$parameters = array('row' => $row, 'selected' => $selected, 'versionNumber' => $versionNumRow);
 					$action = '';
 					$reshook = $hookmanager->executeHooks('listeVersion_customOptions', $parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
 					if ($reshook > 0) $options = $hookmanager->resPrint;
@@ -326,6 +473,9 @@
 				}
 
 				print '</select>';
+
+                print '<input type="hidden" id="propalehistory_version_num_selected" name="propalehistory_version_num_selected" value="' . $versionNumSelected . '" />';
+
 				print '<input class="butAction" id="voir" value="'.$langs->trans('Visualiser').'" type="SUBMIT" />';
 				print '</form>';
 				print '</div>';
@@ -334,20 +484,17 @@
 				<script type="text/javascript">
 					$(document).ready(function(){
 						$("#formListe").appendTo('div.tabsAction');
+
+                        $("#propalehistory_id").change(function() {
+                            var optionSelectedElem = $("option:selected", this);
+                            $("#propalehistory_version_num_selected").val(optionSelectedElem.attr("data-version-num"));
+                        });
 					})
 				</script>
 				<?php
-
-			}
-			else{
-
-				null;
 			}
 
-
-
-
-			return $num;
+			return $versionNumCurrent;
 		}
 
 	}

--- a/core/modules/modPropalehistory.class.php
+++ b/core/modules/modPropalehistory.class.php
@@ -207,6 +207,12 @@ class modPropalehistory extends DolibarrModules
 		$o=new TPropaleHist;
 		$o->init_db_by_vars($PDOdb);
 
+        // Create extrafields
+        include_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+        $extrafields = new ExtraFields($this->db);
+        // proposal version
+        $result = $extrafields->addExtraField('propalehistory_version_num', 'PropaleHistoryVersionNum', 'int', 1000, '', 'propal', 0, 0, '', '', 0, '', '-4', '', '', 0, 'propalehistory@propalehistory', '$conf->propalehistory->enabled', 0);
+
         return $this->_init($sql, $options);
     }
 

--- a/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
+++ b/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
@@ -115,6 +115,7 @@ class InterfacePropalehistory extends DolibarrTriggers
         $db=&$this->db;
 		//echo $action.'<br>';
         if ($action == 'PROPAL_VALIDATE' && $conf->global->PROPALEHISTORY_AUTO_ARCHIVE) {
+            dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 
 			define('INC_FROM_DOLIBARR', true);
 			dol_include_once("/propalehistory/config.php");
@@ -129,11 +130,15 @@ class InterfacePropalehistory extends DolibarrTriggers
 
 			$ATMdb = new TPDOdb;
 
-			TPropaleHist::archiverPropale($ATMdb, $object);
-
-            dol_syslog(
-                "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
-            );
+            /**
+             * @var Propal $object
+             */
+			$result = TPropaleHist::archiverPropale($ATMdb, $object);
+            if ($result < 0) {
+                return -1;
+            } else {
+                return 1;
+            }
         } elseif ($action == 'PROPAL_DELETE') {
             dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 

--- a/langs/en_US/propalehistory.lang
+++ b/langs/en_US/propalehistory.lang
@@ -20,9 +20,11 @@ PropalHistoryAutoArchiveAndArchiveOnModifyCantBeUsedBoth=Archiving at validation
 
 PROPALEHISTORY_ARCHIVE_PDF_TOO=Archive the PDF too
 PROPALEHISTORY_HIDE_VERSION_ON_TABS=Hide version number in tabs
+PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Keep version number on restoring
 
 ReturnInitialVersion=Return initial version
 PropaleHistoryArchiver=Archive
 Visualiser=Show
 Restaurer=Restore
 VersionNumberShort = Version No.
+PropaleHistoryVersionNum = Version number

--- a/langs/fr_FR/propalehistory.lang
+++ b/langs/fr_FR/propalehistory.lang
@@ -20,10 +20,11 @@ PropalHistoryAutoArchiveAndArchiveOnModifyCantBeUsedBoth = L'archivage à la val
 
 PROPALEHISTORY_ARCHIVE_PDF_TOO = Archiver aussi le PDF
 PROPALEHISTORY_HIDE_VERSION_ON_TABS = Masquer le numéro de version dans les onglets
+PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Restaurer une proposition commerciale en gardant le numéro de version
 
 ReturnInitialVersion = Retour version courante
 PropaleHistoryArchiver = Archiver
 Visualiser = Visualiser
 Restaurer = Restaurer
 VersionNumberShort = Version n°
-
+PropaleHistoryVersionNum = Numéro de version


### PR DESCRIPTION
NEW keep version number on restore

- un nouveau paramètre permettant de restaurer une proposition commerciale tout en gardant le numéro de version
![image](https://user-images.githubusercontent.com/45359511/182880333-4a486bb5-9067-446e-af5d-8d2cfc1eebed.png)

Ajout d'un champ complémentaite caché pour savoir sur quelle version on est.
On garde le même fonctionnement qu'avant lorsque cette option n'est pas activée.

Lorsque cette option est activée : 
- on garde le même comportement lorsqu'on archive une version (ex : si on est sur la version 1 et qu'on archive alors on passe au numéro de version suivante)
- lorsqu'on restaure une version alors on garde son numéro au lieu de restaurer sur la version courante
- par contre lorsqu'on supprime une version alors on ne bouche pas les trous pour pouvoir se repérer avec les numéros de version